### PR TITLE
Fix for qmrestore timeout

### DIFF
--- a/default
+++ b/default
@@ -84,6 +84,14 @@ DEFAULT_CHUNKER='9,16,12,4095'
 # Set a default directory for temporary files
 VZBORG_TEMP_DIR="/tmp"
 
+# QMRESTORE DELAY
+#
+# VzBorg restores VM by pipng borg output to qmrestore
+# When borg repository is on slow storage like NFS qmrestore may timeout waiting for input from borg
+# This option artificially introduces delay (in seconds) before starting qmrestore to circumvent that
+#
+# VZBORG_QMRESTORE_DELAY='0'
+
 # EXTRA BORG OPTIONS
 #
 # Example for showing borg progress

--- a/vzborg
+++ b/vzborg
@@ -1003,7 +1003,7 @@ vzborg_restore() {
 
         say "> Restoring backup ${borg_archive} as ${vm_type} ${restore_id} to storage ${restore_storage}"
         if [[ ${vm_type} == 'VM' ]]; then
-            borg extract ${borg_extra} --stdout ${vzborg_repo}::${borg_archive} | qmrestore - ${restore_id} --storage ${restore_storage} ${force_overwrite}
+            borg extract ${borg_extra} --stdout ${vzborg_repo}::${borg_archive} | { sleep ${qmrestore_delay}; qmrestore - ${restore_id} --storage ${restore_storage} ${force_overwrite}; }
         else
             if [[ ${guest_has_mount_points} = true ]]; then
                 #echo 'Guest has mount points, restoring to temporary file'
@@ -1163,6 +1163,7 @@ default_keep=${DEFAULT_KEEP:-'--keep-daily=2 --keep-weekly=4 --keep-monthly=12 -
 default_chunker=${DEFAULT_CHUNKER:-'10,23,16,4095'}
 encryption_mode=${ENCRYPTION_MODE:-'repokey-blake2'}
 temp_dir=${VZBORG_TEMP_DIR:-'/tmp'}
+qmrestore_delay=${VZBORG_QMRESTORE_DELAY:-'0'}
 if [[ -z ${vzborg_repo} ]]; then
     vzborg_repo=${VZBORG_REPO:-'/var/lib/vz/vzborg'}
 fi


### PR DESCRIPTION
This is the workaround we used to circumvent qmrestore timeout error when using slow (NFS) borg repository as described in #11 .
It adds sleep command before invoking qmrestore and time of sleep can be adjusted via VZBORG_QMRESTORE_DELAY variable in "default" file. If not set it defaults to 0.
For us setting it to 7s was enough to get restore to work.