### PR TITLE
use short hostname for conf paths

### DIFF
--- a/vzborg
+++ b/vzborg
@@ -1067,9 +1067,9 @@ vzborg_repo=''
 vzdump_quiet=0
 
 # Containers configuration directory
-ct_conf_dir="/etc/pve/nodes/$(hostname)/lxc/"
+ct_conf_dir="/etc/pve/nodes/$(hostname -s)/lxc/"
 # Qemu virtual machines configuration directory
-vm_conf_dir="/etc/pve/nodes/$(hostname)/qemu-server/"
+vm_conf_dir="/etc/pve/nodes/$(hostname -s)/qemu-server/"
 
 # Load variables from default configuration file
 . /etc/vzborg/default


### PR DESCRIPTION
If the server uses any hostname separated by dots (e.g. an FQDN such as example.com), the current configuration paths don't work, since they'll contain the full hostname "example.com", while proxmox only uses the short hostname "example" for the configuration directory.

This commit fixes this issue by using the short hostname instead.