### PR TITLE
replace usages of --prefix with --glob-archives

### DIFF
--- a/vzborg
+++ b/vzborg
@@ -229,7 +229,7 @@ vzborg_backup() {
         if [[ ${purge_on_backup} = true ]]; then
             SECONDS=0
             say "--> Purging" |& tee -a ${detail_file}
-            if borg prune ${borg_extra} -v -s --list ${dry_run} ${retention} --prefix ${archs_prefix}-${VM_ID} ${vzborg_repo} |& tee -a ${detail_file}; then
+            if borg prune ${borg_extra} -v -s --list ${dry_run} ${retention} --glob-archives ${archs_prefix}-${VM_ID}* ${vzborg_repo} |& tee -a ${detail_file}; then
                 purge_status='done'
             else
                 purge_status='failed'
@@ -806,7 +806,7 @@ vzborg_purge() {
         fi
 
         SECONDS=0
-        if borg prune ${borg_extra} -v -s --list ${dry_run} ${retention} --prefix ${archs_prefix}-${VM_ID} ${vzborg_repo} |& tee -a ${detail_file}; then
+        if borg prune ${borg_extra} -v -s --list ${dry_run} ${retention} --glob-archives ${archs_prefix}-${VM_ID}* ${vzborg_repo} |& tee -a ${detail_file}; then
             purge_status='done'
         else
             purge_status='failed'


### PR DESCRIPTION
--prefix has been deprecated in borg 1.2 and results in a warning each time it is used. Instead, --glob-archives can be used together with a wildcard (*).

In version 2.0, the --glob-archives option will be removed again, so this will need to be adjusted again. --match-archives will be introduced instead: https://borgbackup.readthedocs.io/en/2.0.0b5/usage/help.html#borg-help-match-archives